### PR TITLE
implement context manager for `DotthzFile`

### DIFF
--- a/example.py
+++ b/example.py
@@ -4,10 +4,6 @@ import numpy as np
 from dotthz import DotthzFile, DotthzMeasurement, DotthzMetaData
 
 if __name__ == "__main__":
-
-    # Create a new .thz file
-    file = DotthzFile.new()
-
     # Sample data
     time = np.linspace(0, 1, 100)  # your time array
     data = np.random.rand(100)  # example 3D data array
@@ -17,7 +13,7 @@ if __name__ == "__main__":
     datasets = {"Sample": np.array([time, data]).T}
     measurement.datasets = datasets
 
-    # set meta_data
+    # create meta-data
     meta_data = DotthzMetaData()
     meta_data.user = "John Doe"
     meta_data.version = "1.00"
@@ -26,27 +22,27 @@ if __name__ == "__main__":
 
     measurement.meta_data = meta_data
 
-    file.groups["Measurement"] = measurement
-
     # save the file
     path1 = Path("test1.thz")
-    file.save(path1)
-    del file
-    
+    with DotthzFile(path1, "w") as file:
+        file.write_measurement("Measurement 1", measurement)
+    del file  # optional, not required as the file is already closed
+
     # create and save a second file
     path2 = Path("test2.thz")
-    file = DotthzFile.new()
-    file.groups["Measurment 2"] = measurement
-    file.save(path2)
-    del file
+    with DotthzFile(path2, "w") as file:
+        file.write_measurement("Measurement 2", measurement)
+    del file  # optional, not required as the file is already closed
 
-    # open the file again
-    file = DotthzFile.load(path1)
+    # open the first file again in append mode and the second in read mode
+    with DotthzFile(path1, "a") as file1, DotthzFile(path2) as file2:
+        measurements = file2.get_measurements()
+        for name, measurement in measurements.items():
+            file1.write_measurement(name, measurement)
+    del file1  # optional, not required as the file is already closed
 
-    # add more measurements from the second file
-    file.add_from_file(path2)
-
-    # read the first group (measurement)
-    key = list(file.groups.keys())[0]
-    print(file.groups.get(key).meta_data)
-    print(file.groups.get(key).datasets)
+    with DotthzFile(path1, "r") as file1:
+        # read the first measurement
+        key = list(file1.get_measurements().keys())[0]
+        print(file1.get_measurements().get(key).meta_data)
+        print(file1.get_measurements().get(key).datasets)

--- a/tests/test_dotthz.py
+++ b/tests/test_dotthz.py
@@ -13,50 +13,53 @@ class TestDotthzFile(unittest.TestCase):
             "../test_files/2_VariableTemperature.thz",
         ]
         for path in paths:
-            # Load data from the original file
-            original_dotthz = DotthzFile.load(path)
-
             # Create a temporary file to save the copy
             with NamedTemporaryFile(delete=False) as temp_file:
                 copy_file_path = temp_file.name
 
-            # Save the data to the new temporary file
-            original_dotthz.save(copy_file_path)
+            # Load data from the original file
+            with DotthzFile(path) as original_dotthz_file, DotthzFile(copy_file_path, "w") as copied_dotthz_file:
+                original_measurements = original_dotthz_file.get_measurements()
+                for name, measurement in original_measurements.items():
+                    # Save the data to the new temporary file
+                    copied_dotthz_file.write_measurement(name, measurement)
 
             # Load data from the new copy file
-            copied_dotthz = DotthzFile.load(copy_file_path)
+            with DotthzFile(path) as copied_dotthz_file:
 
-            # Compare the original and copied Dotthz structures
-            self.assertEqual(len(original_dotthz.groups), len(copied_dotthz.groups))
+                # Compare the original and copied Dotthz structures
+                self.assertEqual(len(original_measurements), len(copied_dotthz_file.get_measurements()))
 
-            for group_name, original_measurement in original_dotthz.groups.items():
-                copied_measurement = copied_dotthz.groups.get(group_name)
-                self.assertIsNotNone(copied_measurement)
+                for group_name, original_measurement in original_measurements.items():
+                    copied_measurement = copied_dotthz_file.get_measurement(group_name)
+                    self.assertIsNotNone(copied_measurement)
 
-                # Compare metadata fields
-                self.assertEqual(original_measurement.meta_data.user, copied_measurement.meta_data.user)
-                self.assertEqual(original_measurement.meta_data.email, copied_measurement.meta_data.email)
-                self.assertEqual(original_measurement.meta_data.orcid, copied_measurement.meta_data.orcid)
-                self.assertEqual(original_measurement.meta_data.institution, copied_measurement.meta_data.institution)
-                self.assertEqual(original_measurement.meta_data.description, copied_measurement.meta_data.description)
-                self.assertEqual(original_measurement.meta_data.version, copied_measurement.meta_data.version)
-                self.assertEqual(original_measurement.meta_data.mode, copied_measurement.meta_data.mode)
-                self.assertEqual(original_measurement.meta_data.instrument, copied_measurement.meta_data.instrument)
-                self.assertEqual(original_measurement.meta_data.time, copied_measurement.meta_data.time)
-                self.assertEqual(original_measurement.meta_data.date, copied_measurement.meta_data.date)
+                    # Compare metadata fields
+                    self.assertEqual(original_measurement.meta_data.user, copied_measurement.meta_data.user)
+                    self.assertEqual(original_measurement.meta_data.email, copied_measurement.meta_data.email)
+                    self.assertEqual(original_measurement.meta_data.orcid, copied_measurement.meta_data.orcid)
+                    self.assertEqual(original_measurement.meta_data.institution,
+                                     copied_measurement.meta_data.institution)
+                    self.assertEqual(original_measurement.meta_data.description,
+                                     copied_measurement.meta_data.description)
+                    self.assertEqual(original_measurement.meta_data.version, copied_measurement.meta_data.version)
+                    self.assertEqual(original_measurement.meta_data.mode, copied_measurement.meta_data.mode)
+                    self.assertEqual(original_measurement.meta_data.instrument, copied_measurement.meta_data.instrument)
+                    self.assertEqual(original_measurement.meta_data.time, copied_measurement.meta_data.time)
+                    self.assertEqual(original_measurement.meta_data.date, copied_measurement.meta_data.date)
 
-                # Compare metadata key-value pairs
-                self.assertEqual(original_measurement.meta_data.md, copied_measurement.meta_data.md)
+                    # Compare metadata key-value pairs
+                    self.assertEqual(original_measurement.meta_data.md, copied_measurement.meta_data.md)
 
-                # Compare datasets
-                self.assertEqual(len(original_measurement.datasets), len(copied_measurement.datasets))
-                for dataset_name, original_dataset in original_measurement.datasets.items():
-                    copied_dataset = copied_measurement.datasets.get(dataset_name)
-                    self.assertIsNotNone(copied_dataset)
-                    np.testing.assert_array_equal(original_dataset, copied_dataset)
+                    # Compare datasets
+                    self.assertEqual(len(original_measurement.datasets), len(copied_measurement.datasets))
+                    for dataset_name, original_dataset in original_measurement.datasets.items():
+                        copied_dataset = copied_measurement.datasets.get(dataset_name)
+                        self.assertIsNotNone(copied_dataset)
+                        np.testing.assert_array_equal(original_dataset, copied_dataset)
 
-            # Clean up temporary file
-            os.remove(copy_file_path)
+                # Clean up temporary file
+                os.remove(copy_file_path)
 
     def test_dotthz_save_and_load(self):
         with NamedTemporaryFile(delete=False) as temp_file:
@@ -80,48 +83,47 @@ class TestDotthzFile(unittest.TestCase):
             date="2024-11-08"
         )
 
-        groups = {
-            "group1": DotthzMeasurement(datasets=datasets, meta_data=meta_data)
+        measurements = {
+            "Measurement 1": DotthzMeasurement(datasets=datasets, meta_data=meta_data)
         }
-        file_to_write = DotthzFile(groups=groups)
 
-        # Save to the temporary file
-        file_to_write.save(path)
+        with DotthzFile(path, "w") as file_to_write:
+            for name, measurement in measurements.items():
+                file_to_write.write_measurement(name, measurement)
 
         # Load from the temporary file
-        loaded_file = DotthzFile.load(path)
+        with DotthzFile(path) as loaded_file:
+            # Compare original and loaded data
+            self.assertEqual(len(measurements), len(loaded_file.get_measurements()))
 
-        # Compare original and loaded data
-        self.assertEqual(len(file_to_write.groups), len(loaded_file.groups))
+            for group_name, measurement in file_to_write.get_measurements().items():
+                loaded_measurement = loaded_file.get_measurement(group_name)
+                self.assertIsNotNone(loaded_measurement)
 
-        for group_name, measurement in file_to_write.groups.items():
-            loaded_measurement = loaded_file.groups.get(group_name)
-            self.assertIsNotNone(loaded_measurement)
+                # Compare metadata fields
+                self.assertEqual(measurement.meta_data.user, loaded_measurement.meta_data.user)
+                self.assertEqual(measurement.meta_data.email, loaded_measurement.meta_data.email)
+                self.assertEqual(measurement.meta_data.orcid, loaded_measurement.meta_data.orcid)
+                self.assertEqual(measurement.meta_data.institution, loaded_measurement.meta_data.institution)
+                self.assertEqual(measurement.meta_data.description, loaded_measurement.meta_data.description)
+                self.assertEqual(measurement.meta_data.version, loaded_measurement.meta_data.version)
+                self.assertEqual(measurement.meta_data.mode, loaded_measurement.meta_data.mode)
+                self.assertEqual(measurement.meta_data.instrument, loaded_measurement.meta_data.instrument)
+                self.assertEqual(measurement.meta_data.time, loaded_measurement.meta_data.time)
+                self.assertEqual(measurement.meta_data.date, loaded_measurement.meta_data.date)
 
-            # Compare metadata fields
-            self.assertEqual(measurement.meta_data.user, loaded_measurement.meta_data.user)
-            self.assertEqual(measurement.meta_data.email, loaded_measurement.meta_data.email)
-            self.assertEqual(measurement.meta_data.orcid, loaded_measurement.meta_data.orcid)
-            self.assertEqual(measurement.meta_data.institution, loaded_measurement.meta_data.institution)
-            self.assertEqual(measurement.meta_data.description, loaded_measurement.meta_data.description)
-            self.assertEqual(measurement.meta_data.version, loaded_measurement.meta_data.version)
-            self.assertEqual(measurement.meta_data.mode, loaded_measurement.meta_data.mode)
-            self.assertEqual(measurement.meta_data.instrument, loaded_measurement.meta_data.instrument)
-            self.assertEqual(measurement.meta_data.time, loaded_measurement.meta_data.time)
-            self.assertEqual(measurement.meta_data.date, loaded_measurement.meta_data.date)
+                # Compare metadata's key-value pairs
+                self.assertEqual(measurement.meta_data.md, loaded_measurement.meta_data.md)
 
-            # Compare metadata's key-value pairs
-            self.assertEqual(measurement.meta_data.md, loaded_measurement.meta_data.md)
+                # Compare datasets
+                self.assertEqual(len(measurement.datasets), len(loaded_measurement.datasets))
+                for dataset_name, dataset in measurement.datasets.items():
+                    loaded_dataset = loaded_measurement.datasets.get(dataset_name)
+                    self.assertIsNotNone(loaded_dataset)
+                    np.testing.assert_array_equal(dataset, loaded_dataset)
 
-            # Compare datasets
-            self.assertEqual(len(measurement.datasets), len(loaded_measurement.datasets))
-            for dataset_name, dataset in measurement.datasets.items():
-                loaded_dataset = loaded_measurement.datasets.get(dataset_name)
-                self.assertIsNotNone(loaded_dataset)
-                np.testing.assert_array_equal(dataset, loaded_dataset)
-
-        # Clean up temporary file
-        os.remove(path)
+            # Clean up temporary file
+            os.remove(path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Files can now be handled like this:

```python
# open the first file again in append mode and the second in read mode
    with DotthzFile(path1, "a") as file1, DotthzFile(path2) as file2:
        measurements = file2.get_measurements()
        for name, measurement in measurements.items():
            file1.write_measurement(name, measurement)
    del file1  # optional, not required as the file is already closed

    with DotthzFile(path1, "r") as file1:
        # read the first measurement
        key = list(file1.get_measurements().keys())[0]
        print(file1.get_measurements().get(key).meta_data)
        print(file1.get_measurements().get(key).datasets)
```