### PR TITLE
add direct writing to file (and get_item/set_item)

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   Check-Changelog:
     name: Check Changelog Action
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: tarides/changelog-check-action@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to the `pydotthz` package will be documented in this file.
 
 # Unreleased
 
+* ...
+
+# 1.0.0
+
+### Added:
+
+* `DotTHzFile` now allows accessing measurements like a dictionary: `file[name]`
+* When setting a measurement value either in `file[name]` or `file.measurements[name]` it is automatically written to
+  the file on the disk.
+
+### Deprecated:
+
+* Usage of `file.get_measurements()` is replaced by `file.measurements`
+* Usage of `file.get_measurement(name)` is replaced by `file[name]` or `file.measurements[name]`
+
 ### Breaking:
 
 * Changed import name from `dotthz` to `pydotthz` for consistency

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ and then use like specified in the following example:
 ```python
 from pathlib import Path
 import numpy as np
-
 from pydotthz import DotthzFile, DotthzMeasurement, DotthzMetaData
 
 if __name__ == "__main__":
@@ -48,20 +47,20 @@ if __name__ == "__main__":
     # save the file
     path1 = Path("test1.thz")
     with DotthzFile(path1, "w") as file:
-        file.write_measurement("Measurement 1", measurement)
+        file["Measurement 1"] = measurement
     del file  # optional, not required as the file is already closed
 
     # create and save a second file
     path2 = Path("test2.thz")
     with DotthzFile(path2, "w") as file:
-        file.write_measurement("Measurement 2", measurement)
+        file["Measurement 2"] = measurement
     del file  # optional, not required as the file is already closed
 
     # open the first file again in append mode and the second in read mode
     with DotthzFile(path1, "a") as file1, DotthzFile(path2) as file2:
         measurements = file2.measurements
         for name, measurement in measurements.items():
-            file1.write_measurement(name, measurement)
+            file1[name] =  measurement
     del file1  # optional, not required as the file is already closed
 
     with DotthzFile(path1, "r") as file1:

--- a/README.md
+++ b/README.md
@@ -30,24 +30,23 @@ if __name__ == "__main__":
     time = np.linspace(0, 1, 100)  # your time array
     data = np.random.rand(100)  # example 3D data array
 
-    measurement = DotthzMeasurement()
-    # for thzVer 1.00, we need to transpose the array!
-    datasets = {"Sample": np.array([time, data]).T}
-    measurement.datasets = datasets
-
-    # create meta-data
-    meta_data = DotthzMetaData()
-    meta_data.user = "John Doe"
-    meta_data.version = "1.00"
-    meta_data.instrument = "Toptica TeraFlash Pro"
-    meta_data.mode = "THz-TDS/Transmission"
-
-    measurement.meta_data = meta_data
-
     # save the file
     path1 = Path("test1.thz")
     with DotthzFile(path1, "w") as file:
-        file["Measurement 1"] = measurement
+        file["Measurement 1"] = DotthzMeasurement()
+
+        # create meta-data
+        meta_data = DotthzMetaData()
+        meta_data.user = "John Doe"
+        meta_data.version = "1.00"
+        meta_data.instrument = "Toptica TeraFlash Pro"
+        meta_data.mode = "THz-TDS/Transmission"
+
+        file["Measurement 1"].meta_data = meta_data
+
+        # for thzVer 1.00, we need to transpose the array!
+        file["Measurement 1"].datasets["Sample"] = np.array([time, data]).T
+
     del file  # optional, not required as the file is already closed
 
     # create and save a second file
@@ -60,7 +59,7 @@ if __name__ == "__main__":
     with DotthzFile(path1, "a") as file1, DotthzFile(path2) as file2:
         measurements = file2.measurements
         for name, measurement in measurements.items():
-            file1[name] =  measurement
+            file1[name] = measurement
     del file1  # optional, not required as the file is already closed
 
     with DotthzFile(path1, "r") as file1:
@@ -90,10 +89,6 @@ if __name__ == "__main__":
     with DotthzFile(path4, "w") as file:
 
         file.measurements["Image"] = DotthzMeasurement()
-        file.measurements["Image"].datasets = {}
-
-        file.measurements["Image"].datasets["time"] = time_trace
-        file.measurements["Image"].datasets["dataset"] = image
 
         # set meta_data
         meta_data = DotthzMetaData()
@@ -113,6 +108,9 @@ if __name__ == "__main__":
         #    meta_data.add_field(key, value)
 
         file.measurements["Image"].meta_data = meta_data
+
+        file.measurements["Image"].datasets["time"] = time_trace
+        file.measurements["Image"].datasets["dataset"] = image
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Interface with dotTHz files using Python
+
 [![PEP8](https://github.com/dotTHzTAG/pydotthz/actions/workflows/format.yml/badge.svg)](https://github.com/dotTHzTAG/pydotthz/actions/workflows/format.yml)
 [![PyPI](https://img.shields.io/pypi/v/pydotthz?label=pypi%20package)](https://pypi.org/project/pydotthz/)
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/pydotthz)](https://pypi.org/project/pydotthz/)
@@ -10,7 +11,9 @@ Install it
 ```shell
 pip install pydotthz
 ```
+
 or
+
 ```shell
 pip3 install pydotthz
 ```
@@ -56,24 +59,24 @@ if __name__ == "__main__":
 
     # open the first file again in append mode and the second in read mode
     with DotthzFile(path1, "a") as file1, DotthzFile(path2) as file2:
-        measurements = file2.get_measurements()
+        measurements = file2.measurements
         for name, measurement in measurements.items():
             file1.write_measurement(name, measurement)
     del file1  # optional, not required as the file is already closed
 
     with DotthzFile(path1, "r") as file1:
         # read the first measurement
-        key = list(file1.get_measurements().keys())[0]
-        print(file1.get_measurements().get(key).meta_data)
-        print(file1.get_measurements().get(key).datasets)
+        key = list(file1.measurements.keys())[0]
+        print(file1.measurements.get(key).meta_data)
+        print(file1.measurements.get(key).datasets)
 
     # read out an image file:
-    path3 = Path("test_files/test_image.thz")
+    path3 = Path("tests/test_files/test_image.thz")
     with DotthzFile(path3, "r") as image_file:
         # read the first group/measurement
-        key = list(image_file.get_measurements().keys())[0]
-        print(image_file.get_measurements().get(key).meta_data)
-        datasets = image_file.get_measurements().get(key).datasets
+        key = list(image_file.measurements.keys())[0]
+        print(image_file.measurements.get(key).meta_data)
+        datasets = image_file.measurements.get(key).datasets
         print(datasets.keys())
 
         # from the first dataset, extract the image:
@@ -84,15 +87,14 @@ if __name__ == "__main__":
         print(image.shape)
 
     # save an image file:
-    path4 = Path("test_files/test_image_2.thz")
+    path4 = Path("tests/test_files/test_image_2.thz")
     with DotthzFile(path4, "w") as file:
-        file.groups = {}
 
-        measurement = DotthzMeasurement()
-        measurement.datasets = {}
+        file.measurements["Image"] = DotthzMeasurement()
+        file.measurements["Image"].datasets = {}
 
-        measurement.datasets[f"time"] = time_trace
-        measurement.datasets[f"dataset"] = image
+        file.measurements["Image"].datasets["time"] = time_trace
+        file.measurements["Image"].datasets["dataset"] = image
 
         # set meta_data
         meta_data = DotthzMetaData()
@@ -111,8 +113,8 @@ if __name__ == "__main__":
         # for (key, value) in info.items():
         #    meta_data.add_field(key, value)
 
-        measurement.meta_data = meta_data
-        file.groups[f"Image"] = measurement
+        file.measurements["Image"].meta_data = meta_data
 
 ```
+
 Requires hdf5 to be installed.

--- a/README.md
+++ b/README.md
@@ -45,14 +45,15 @@ if __name__ == "__main__":
         file["Measurement 1"].meta_data = meta_data
 
         # for thzVer 1.00, we need to transpose the array!
-        file["Measurement 1"].datasets["Sample"] = np.array([time, data]).T
+        # important: do not manipulate keys on the `dataset` field, otherwise it won't be written to the file.
+        file["Measurement 1"]["Sample"] = np.array([time, data]).T
 
     del file  # optional, not required as the file is already closed
 
     # create and save a second file
     path2 = Path("test2.thz")
     with DotthzFile(path2, "w") as file:
-        file["Measurement 2"] = measurement
+        file["Measurement 2"] = DotthzMeasurement()
     del file  # optional, not required as the file is already closed
 
     # open the first file again in append mode and the second in read mode
@@ -109,8 +110,9 @@ if __name__ == "__main__":
 
         file.measurements["Image"].meta_data = meta_data
 
-        file.measurements["Image"].datasets["time"] = time_trace
-        file.measurements["Image"].datasets["dataset"] = image
+        # important: do not manipulate keys on the `dataset` field, otherwise it won't be written to the file.
+        file.measurements["Image"]["time"] = time_trace
+        file.measurements["Image"]["dataset"] = image
 
 ```
 

--- a/example.py
+++ b/example.py
@@ -24,20 +24,20 @@ if __name__ == "__main__":
     # save the file
     path1 = Path("test1.thz")
     with DotthzFile(path1, "w") as file:
-        file.write_measurement("Measurement 1", measurement)
+        file["Measurement 1"] = measurement
     del file  # optional, not required as the file is already closed
 
     # create and save a second file
     path2 = Path("test2.thz")
     with DotthzFile(path2, "w") as file:
-        file.write_measurement("Measurement 2", measurement)
+        file["Measurement 2"] = measurement
     del file  # optional, not required as the file is already closed
 
     # open the first file again in append mode and the second in read mode
     with DotthzFile(path1, "a") as file1, DotthzFile(path2) as file2:
         measurements = file2.measurements
         for name, measurement in measurements.items():
-            file1.write_measurement(name, measurement)
+            file1[name] =  measurement
     del file1  # optional, not required as the file is already closed
 
     with DotthzFile(path1, "r") as file1:

--- a/example.py
+++ b/example.py
@@ -7,24 +7,23 @@ if __name__ == "__main__":
     time = np.linspace(0, 1, 100)  # your time array
     data = np.random.rand(100)  # example 3D data array
 
-    measurement = DotthzMeasurement()
-    # for thzVer 1.00, we need to transpose the array!
-    datasets = {"Sample": np.array([time, data]).T}
-    measurement.datasets = datasets
-
-    # create meta-data
-    meta_data = DotthzMetaData()
-    meta_data.user = "John Doe"
-    meta_data.version = "1.00"
-    meta_data.instrument = "Toptica TeraFlash Pro"
-    meta_data.mode = "THz-TDS/Transmission"
-
-    measurement.meta_data = meta_data
-
     # save the file
     path1 = Path("test1.thz")
     with DotthzFile(path1, "w") as file:
-        file["Measurement 1"] = measurement
+        file["Measurement 1"] = DotthzMeasurement()
+
+        # create meta-data
+        meta_data = DotthzMetaData()
+        meta_data.user = "John Doe"
+        meta_data.version = "1.00"
+        meta_data.instrument = "Toptica TeraFlash Pro"
+        meta_data.mode = "THz-TDS/Transmission"
+
+        file["Measurement 1"].meta_data = meta_data
+
+        # for thzVer 1.00, we need to transpose the array!
+        file["Measurement 1"].datasets["Sample"] = np.array([time, data]).T
+
     del file  # optional, not required as the file is already closed
 
     # create and save a second file
@@ -37,7 +36,7 @@ if __name__ == "__main__":
     with DotthzFile(path1, "a") as file1, DotthzFile(path2) as file2:
         measurements = file2.measurements
         for name, measurement in measurements.items():
-            file1[name] =  measurement
+            file1[name] = measurement
     del file1  # optional, not required as the file is already closed
 
     with DotthzFile(path1, "r") as file1:
@@ -67,10 +66,6 @@ if __name__ == "__main__":
     with DotthzFile(path4, "w") as file:
 
         file.measurements["Image"] = DotthzMeasurement()
-        file.measurements["Image"].datasets = {}
-
-        file.measurements["Image"].datasets["time"] = time_trace
-        file.measurements["Image"].datasets["dataset"] = image
 
         # set meta_data
         meta_data = DotthzMetaData()
@@ -90,3 +85,6 @@ if __name__ == "__main__":
         #    meta_data.add_field(key, value)
 
         file.measurements["Image"].meta_data = meta_data
+
+        file.measurements["Image"].datasets["time"] = time_trace
+        file.measurements["Image"].datasets["dataset"] = image

--- a/example.py
+++ b/example.py
@@ -22,14 +22,15 @@ if __name__ == "__main__":
         file["Measurement 1"].meta_data = meta_data
 
         # for thzVer 1.00, we need to transpose the array!
-        file["Measurement 1"].datasets["Sample"] = np.array([time, data]).T
+        # important: do not manipulate keys on the `dataset` field, otherwise it won't be written to the file.
+        file["Measurement 1"]["Sample"] = np.array([time, data]).T
 
     del file  # optional, not required as the file is already closed
 
     # create and save a second file
     path2 = Path("test2.thz")
     with DotthzFile(path2, "w") as file:
-        file["Measurement 2"] = measurement
+        file["Measurement 2"] = DotthzMeasurement()
     del file  # optional, not required as the file is already closed
 
     # open the first file again in append mode and the second in read mode
@@ -86,5 +87,6 @@ if __name__ == "__main__":
 
         file.measurements["Image"].meta_data = meta_data
 
-        file.measurements["Image"].datasets["time"] = time_trace
-        file.measurements["Image"].datasets["dataset"] = image
+        # important: do not manipulate keys on the `dataset` field, otherwise it won't be written to the file.
+        file.measurements["Image"]["time"] = time_trace
+        file.measurements["Image"]["dataset"] = image

--- a/example.py
+++ b/example.py
@@ -35,24 +35,24 @@ if __name__ == "__main__":
 
     # open the first file again in append mode and the second in read mode
     with DotthzFile(path1, "a") as file1, DotthzFile(path2) as file2:
-        measurements = file2.get_measurements()
+        measurements = file2.measurements
         for name, measurement in measurements.items():
             file1.write_measurement(name, measurement)
     del file1  # optional, not required as the file is already closed
 
     with DotthzFile(path1, "r") as file1:
         # read the first measurement
-        key = list(file1.get_measurements().keys())[0]
-        print(file1.get_measurements().get(key).meta_data)
-        print(file1.get_measurements().get(key).datasets)
+        key = list(file1.measurements.keys())[0]
+        print(file1.measurements.get(key).meta_data)
+        print(file1.measurements.get(key).datasets)
 
     # read out an image file:
     path3 = Path("tests/test_files/test_image.thz")
     with DotthzFile(path3, "r") as image_file:
         # read the first group/measurement
-        key = list(image_file.get_measurements().keys())[0]
-        print(image_file.get_measurements().get(key).meta_data)
-        datasets = image_file.get_measurements().get(key).datasets
+        key = list(image_file.measurements.keys())[0]
+        print(image_file.measurements.get(key).meta_data)
+        datasets = image_file.measurements.get(key).datasets
         print(datasets.keys())
 
         # from the first dataset, extract the image:
@@ -65,13 +65,12 @@ if __name__ == "__main__":
     # save an image file:
     path4 = Path("tests/test_files/test_image_2.thz")
     with DotthzFile(path4, "w") as file:
-        file.groups = {}
 
-        measurement = DotthzMeasurement()
-        measurement.datasets = {}
+        file.measurements["Image"] = DotthzMeasurement()
+        file.measurements["Image"].datasets = {}
 
-        measurement.datasets["time"] = time_trace
-        measurement.datasets["dataset"] = image
+        file.measurements["Image"].datasets["time"] = time_trace
+        file.measurements["Image"].datasets["dataset"] = image
 
         # set meta_data
         meta_data = DotthzMetaData()
@@ -90,5 +89,4 @@ if __name__ == "__main__":
         # for (key, value) in info.items():
         #    meta_data.add_field(key, value)
 
-        measurement.meta_data = meta_data
-        file.groups["Image"] = measurement
+        file.measurements["Image"].meta_data = meta_data

--- a/pydotthz/pydotthz.py
+++ b/pydotthz/pydotthz.py
@@ -145,6 +145,9 @@ class DotthzMeasurement:
     _datasets: Dict[str, np.ndarray] = field(default_factory=dict, repr=False)
     _meta_data: DotthzMetaData = field(default_factory=DotthzMetaData, repr=False)
 
+    def __str__(self):
+        return f"{self._meta_data} {self._datasets}"
+
     @property
     def datasets(self):
         return self._datasets

--- a/pydotthz/pydotthz.py
+++ b/pydotthz/pydotthz.py
@@ -158,7 +158,7 @@ class DotthzMeasurement:
         self.datasets[key] = value
         # Here we can trigger the save method manually (optional depending on design)
         # This will ensure the measurement is written when a dataset is updated
-        if hasattr(self, '_file'):
+        if hasattr(self, '_file') and hasattr(self, '_measurement_name'):
             self._file.write_measurement(self._measurement_name, self)
 
 
@@ -411,8 +411,7 @@ class DotthzFile:
             else:
                 group.create_dataset(ds_name, data=dataset)
 
-            # Store a reference to the HDF5 dataset in the wrapper
-            measurement.datasets[name] = np.array(group[ds_name])
+            measurement.datasets[name] = group[ds_name]
 
         # Write metadata
         for attr_name, attr_value in measurement.meta_data.__dict__.items():

--- a/pydotthz/pydotthz.py
+++ b/pydotthz/pydotthz.py
@@ -139,6 +139,25 @@ class MeasurementDict(dict):
 
 @dataclass
 class DotthzMeasurement:
+    """
+    A data class representing a single terahertz measurement.
+
+    This class holds both the metadata and the datasets associated with a measurement.
+    It includes automatic persistence support: when either `datasets` or `meta_data` is modified,
+    and the measurement is part of a `DotthzFile`, the corresponding file is updated.
+
+    Attributes
+    ----------
+    _file : DotthzFile, optional
+        Reference to the parent `DotthzFile` object. Used to trigger automatic saving.
+    _measurement_name : str, optional
+        The name of the measurement within the file. Used for file I/O.
+    _datasets : dict of str -> np.ndarray
+        Dictionary of datasets related to the measurement.
+    _meta_data : DotthzMetaData
+        Metadata associated with the measurement.
+    """
+
     _file: "DotthzFile" = field(default=None, repr=False, compare=False)
     _measurement_name: str = field(default=None, repr=False, compare=False)
 
@@ -146,32 +165,96 @@ class DotthzMeasurement:
     _meta_data: DotthzMetaData = field(default_factory=DotthzMetaData, repr=False)
 
     def __str__(self):
+        """
+        Return a string representation of the measurement, showing its metadata and dataset keys.
+        """
         return f"{self._meta_data} {self._datasets}"
 
     @property
-    def datasets(self):
+    def datasets(self) -> Dict[str, np.ndarray]:
+        """
+        Access the datasets of the measurement.
+
+        Returns
+        -------
+        dict
+            Dictionary mapping dataset names to NumPy arrays.
+        """
         return self._datasets
 
     @datasets.setter
-    def datasets(self, value):
+    def datasets(self, value: Dict[str, np.ndarray]):
+        """
+        Set the datasets for the measurement.
+
+        Automatically triggers a write to the associated file if available.
+
+        Parameters
+        ----------
+        value : dict
+            Dictionary of datasets to assign.
+        """
         self._datasets = value
         if self._file and self._measurement_name:
             self._file.write_measurement(self._measurement_name, self)
 
     @property
-    def meta_data(self):
+    def meta_data(self) -> DotthzMetaData:
+        """
+        Access the metadata of the measurement.
+
+        Returns
+        -------
+        DotthzMetaData
+            The metadata object.
+        """
         return self._meta_data
 
     @meta_data.setter
-    def meta_data(self, value):
+    def meta_data(self, value: DotthzMetaData):
+        """
+        Set the metadata for the measurement.
+
+        Automatically triggers a write to the associated file if available.
+
+        Parameters
+        ----------
+        value : DotthzMetaData
+            Metadata object to assign.
+        """
         self._meta_data = value
         if self._file and self._measurement_name:
             self._file.write_measurement(self._measurement_name, self)
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> np.ndarray:
+        """
+        Access an individual dataset by name using indexing syntax.
+
+        Parameters
+        ----------
+        key : str
+            The name of the dataset to retrieve.
+
+        Returns
+        -------
+        np.ndarray
+            The requested dataset.
+        """
         return self._datasets[key]
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: str, value: np.ndarray):
+        """
+        Set or replace an individual dataset by name using indexing syntax.
+
+        Automatically triggers a write to the associated file if available.
+
+        Parameters
+        ----------
+        key : str
+            The name of the dataset.
+        value : np.ndarray
+            The dataset to assign.
+        """
         self._datasets[key] = value
         if self._file and self._measurement_name:
             self._file.write_measurement(self._measurement_name, self)

--- a/pydotthz/pydotthz.py
+++ b/pydotthz/pydotthz.py
@@ -56,11 +56,68 @@ class DotthzMetaData:
 
 
 class MeasurementDict(dict):
+    """
+       A custom dictionary-like class that wraps around the standard Python dictionary.
+
+       This class is designed to store `DotthzMeasurement` objects and ensure that
+       whenever a new measurement is added or modified, the corresponding measurement
+       is written to the file using the `write_measurement()` method.
+
+       Inherits from `dict` to retain normal dictionary behavior (e.g., iteration,
+       item retrieval), while adding the functionality of writing measurements to
+       an HDF5 file automatically.
+
+       Attributes
+       ----------
+       _file : DotthzFile
+           A reference to the `DotthzFile` instance to which measurements will be written.
+
+       Methods
+       -------
+       __setitem__(self, key, value):
+           Adds a new measurement to the dictionary and automatically writes it to the file.
+
+       __init__(self, base_file, *args, **kwargs):
+           Initializes the `MeasurementDict` and stores a reference to the parent `DotthzFile`.
+       """
+
     def __init__(self, base_file, *args, **kwargs):
+        """
+        Initializes the `MeasurementDict` object.
+
+        Parameters
+        ----------
+        base_file : DotthzFile
+            A reference to the `DotthzFile` instance that will be used to write measurements.
+        *args : tuple
+            Positional arguments passed to the parent `dict` constructor.
+        **kwargs : dict
+            Keyword arguments passed to the parent `dict` constructor.
+        """
         super().__init__(*args, **kwargs)
         self._file = base_file
 
     def __setitem__(self, key, value):
+        """
+        Adds a new `DotthzMeasurement` to the dictionary and writes it to the file.
+
+        When a new measurement is assigned to the dictionary using the key-value syntax
+        (i.e., `measurement_dict[key] = value`), this method is called. It ensures that
+        the `value` is a valid `DotthzMeasurement` object and then automatically calls
+        the `write_measurement()` method of `DotthzFile` to store the measurement.
+
+        Parameters
+        ----------
+        key : str
+           The key under which the measurement will be stored (usually the measurement name).
+        value : DotthzMeasurement
+           The `DotthzMeasurement` object that is being added to the dictionary.
+
+        Raises
+        ------
+        TypeError
+           If `value` is not an instance of `DotthzMeasurement`.
+        """
         if not isinstance(value, DotthzMeasurement):
             raise TypeError("Value must be a DotthzMeasurement.")
         super().__setitem__(key, value)

--- a/pydotthz/pydotthz.py
+++ b/pydotthz/pydotthz.py
@@ -247,7 +247,7 @@ class DotthzFile:
     def _sanatize(self, md_in):
         # Reduces redundant iterables to base data.
 
-        if isinstance(md_in, Iterable) and len(md_in) == 1:
+        if isinstance(md_in, np.ndarray) and len(md_in) == 1:
             return self._sanatize(md_in[0])
         else:
             return md_in

--- a/pydotthz/pydotthz.py
+++ b/pydotthz/pydotthz.py
@@ -16,7 +16,6 @@ Dependencies:
 -------------
 - numpy
 - h5py
-- dataclasses
 """
 
 from dataclasses import dataclass, field

--- a/pydotthz/pydotthz.py
+++ b/pydotthz/pydotthz.py
@@ -423,23 +423,11 @@ class DotthzFile:
 
         self._measurements.update(groups)
 
-    def load(self, path):
-        """Load measurements from a .thz file at the path to the file object.
-
-        Parameters
-        ----------
-        path : str
-            The path to the file.
-        """
-        file = h5py.File(path, 'r')
-        self._load(file)
-        file.close()
-
     def get_measurements(self):
         """
         Return a dict of all measurements in the file object.
 
-        .. deprecated:: 1.0
+        .. deprecated:: 1.0.0
             Use `file.measurements` instead.
         """
         warnings.warn(
@@ -457,7 +445,7 @@ class DotthzFile:
     def get_measurement(self, name):
         """Return the specified measurement from the file object.
 
-        .. deprecated:: 1.0
+        .. deprecated:: 1.0.0
             Use `file.measurements[name]` or `file[name]` instead.
 
         Parameters

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["pydotthz"]
 
 [project]
 name = "pydotthz"
-version = "0.4.0"
+version = "1.0.0"
 authors = [
   { name="Linus Leo Stöckli", email="linus.stoeckli@unibe.ch" },
   { name="Jasper Nelson Ward-Berry", email="jnw35@cam.ac.uk" },

--- a/tests/test_dotthz.py
+++ b/tests/test_dotthz.py
@@ -24,8 +24,8 @@ class TestDotthzFile(unittest.TestCase):
                 copied_dotthz_file.measurements = original_measurements
 
             # Load data from the new copy file
-            with DotthzFile(path) as copied_dotthz_file:
-
+            with DotthzFile(path) as original_dotthz_file, DotthzFile(copy_file_path) as copied_dotthz_file:
+                original_measurements = original_dotthz_file.measurements
                 # Compare the original and copied Dotthz structures
                 self.assertEqual(len(original_measurements), len(copied_dotthz_file.measurements))
 
@@ -68,6 +68,10 @@ class TestDotthzFile(unittest.TestCase):
         datasets = {
             "ds1": np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
         }
+
+        # create deep copy
+        original_datasets = {key: val for key, val in datasets.items()}
+
         meta_data = DotthzMetaData(
             user="Test User",
             email="test@example.com",
@@ -96,31 +100,30 @@ class TestDotthzFile(unittest.TestCase):
             # Compare original and loaded data
             self.assertEqual(len(measurements), len(loaded_file.measurements))
 
-            for group_name, measurement in file_to_write.measurements.items():
-                loaded_measurement = loaded_file.measurements[group_name]
-                self.assertIsNotNone(loaded_measurement)
+            loaded_measurement = loaded_file.measurements["Measurement 1"]
+            self.assertIsNotNone(loaded_measurement)
 
-                # Compare metadata fields
-                self.assertEqual(measurement.meta_data.user, loaded_measurement.meta_data.user)
-                self.assertEqual(measurement.meta_data.email, loaded_measurement.meta_data.email)
-                self.assertEqual(measurement.meta_data.orcid, loaded_measurement.meta_data.orcid)
-                self.assertEqual(measurement.meta_data.institution, loaded_measurement.meta_data.institution)
-                self.assertEqual(measurement.meta_data.description, loaded_measurement.meta_data.description)
-                self.assertEqual(measurement.meta_data.version, loaded_measurement.meta_data.version)
-                self.assertEqual(measurement.meta_data.mode, loaded_measurement.meta_data.mode)
-                self.assertEqual(measurement.meta_data.instrument, loaded_measurement.meta_data.instrument)
-                self.assertEqual(measurement.meta_data.time, loaded_measurement.meta_data.time)
-                self.assertEqual(measurement.meta_data.date, loaded_measurement.meta_data.date)
+            # Compare metadata fields
+            self.assertEqual(meta_data.user, loaded_measurement.meta_data.user)
+            self.assertEqual(meta_data.email, loaded_measurement.meta_data.email)
+            self.assertEqual(meta_data.orcid, loaded_measurement.meta_data.orcid)
+            self.assertEqual(meta_data.institution, loaded_measurement.meta_data.institution)
+            self.assertEqual(meta_data.description, loaded_measurement.meta_data.description)
+            self.assertEqual(meta_data.version, loaded_measurement.meta_data.version)
+            self.assertEqual(meta_data.mode, loaded_measurement.meta_data.mode)
+            self.assertEqual(meta_data.instrument, loaded_measurement.meta_data.instrument)
+            self.assertEqual(meta_data.time, loaded_measurement.meta_data.time)
+            self.assertEqual(meta_data.date, loaded_measurement.meta_data.date)
 
-                # Compare metadata's key-value pairs
-                self.assertEqual(measurement.meta_data.md, loaded_measurement.meta_data.md)
+            # Compare metadata's key-value pairs
+            self.assertEqual(meta_data.md, loaded_measurement.meta_data.md)
 
-                # Compare datasets
-                self.assertEqual(len(measurement.datasets), len(loaded_measurement.datasets))
-                for dataset_name, dataset in measurement.datasets.items():
-                    loaded_dataset = loaded_measurement.datasets.get(dataset_name)
-                    self.assertIsNotNone(loaded_dataset)
-                    np.testing.assert_array_equal(dataset, loaded_dataset)
+            # Compare datasets
+            self.assertEqual(len(original_datasets), len(loaded_measurement.datasets))
+            for dataset_name, dataset in original_datasets.items():
+                loaded_dataset = loaded_measurement.datasets.get(dataset_name)
+                self.assertIsNotNone(loaded_dataset)
+                np.testing.assert_array_equal(dataset, loaded_dataset)
 
         # Clean up temporary file
         os.remove(path)
@@ -133,6 +136,10 @@ class TestDotthzFile(unittest.TestCase):
         datasets = {
             "ds1": np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
         }
+
+        # create deep copy
+        original_datasets = {key: val for key, val in datasets.items()}
+
         meta_data = DotthzMetaData(
             user="Test User",
             email="test@example.com",
@@ -160,6 +167,74 @@ class TestDotthzFile(unittest.TestCase):
             # Compare original and loaded data
             self.assertEqual(len(measurements), len(loaded_file.measurements))
 
+            loaded_measurement = loaded_file["Measurement 1"]
+            self.assertIsNotNone(loaded_measurement)
+
+            # Compare metadata fields
+            self.assertEqual(meta_data.user, loaded_measurement.meta_data.user)
+            self.assertEqual(meta_data.email, loaded_measurement.meta_data.email)
+            self.assertEqual(meta_data.orcid, loaded_measurement.meta_data.orcid)
+            self.assertEqual(meta_data.institution, loaded_measurement.meta_data.institution)
+            self.assertEqual(meta_data.description, loaded_measurement.meta_data.description)
+            self.assertEqual(meta_data.version, loaded_measurement.meta_data.version)
+            self.assertEqual(meta_data.mode, loaded_measurement.meta_data.mode)
+            self.assertEqual(meta_data.instrument, loaded_measurement.meta_data.instrument)
+            self.assertEqual(meta_data.time, loaded_measurement.meta_data.time)
+            self.assertEqual(meta_data.date, loaded_measurement.meta_data.date)
+
+            # Compare metadata's key-value pairs
+            self.assertEqual(meta_data.md, loaded_measurement.meta_data.md)
+
+            # Compare datasets
+            self.assertEqual(len(original_datasets), len(loaded_measurement.datasets))
+            for dataset_name, dataset in original_datasets.items():
+                loaded_dataset = loaded_measurement.datasets[dataset_name]
+                self.assertIsNotNone(loaded_dataset)
+                np.testing.assert_array_equal(dataset, loaded_dataset)
+
+        # Clean up temporary file
+        os.remove(path)
+
+    def test_dotthz_extend_existing_dataset(self):
+        with NamedTemporaryFile(delete=False) as temp_file:
+            path = temp_file.name
+
+        # Initialize test data for Dotthz
+        datasets = {
+            "ds1": np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
+        }
+        meta_data = DotthzMetaData(
+            user="Test User",
+            email="test@example.com",
+            orcid="0000-0001-2345-6789",
+            institution="Test Institute",
+            description="Test description",
+            md={"md1": "Thickness (mm)"},
+            version="1.00",
+            mode="Test mode",
+            instrument="Test instrument",
+            time="12:34:56",
+            date="2024-11-08"
+        )
+
+        measurements = {
+            "Measurement 1": DotthzMeasurement(datasets=datasets, meta_data=meta_data)
+        }
+
+        with DotthzFile(path, "w") as file_to_write:
+
+            for name, measurement in measurements.items():
+                file_to_write.measurements[name] = measurement
+            file_to_write.measurements["Measurement 1"].datasets["ds1"][0, 0] = 0.0
+
+        # with DotthzFile(path, "r+") as file_to_extend:
+        #     file_to_extend.measurements["Measurement 1"].datasets["ds1"][0, 0] = 0.0
+
+        # Load from the temporary file
+        with DotthzFile(path) as loaded_file:
+            # Compare original and loaded data
+            self.assertEqual(len(measurements), len(loaded_file.measurements))
+
             for group_name, measurement in file_to_write.measurements.items():
                 loaded_measurement = loaded_file[group_name]
                 self.assertIsNotNone(loaded_measurement)
@@ -181,10 +256,11 @@ class TestDotthzFile(unittest.TestCase):
 
                 # Compare datasets
                 self.assertEqual(len(measurement.datasets), len(loaded_measurement.datasets))
+
                 for dataset_name, dataset in measurement.datasets.items():
                     loaded_dataset = loaded_measurement.datasets[dataset_name]
                     self.assertIsNotNone(loaded_dataset)
-                    np.testing.assert_array_equal(dataset, loaded_dataset)
+                    np.testing.assert_array_equal(loaded_dataset, np.array([[0.0, 2.0], [3.0, 4.0]], dtype=np.float32))
 
         # Clean up temporary file
         os.remove(path)
@@ -212,7 +288,7 @@ class TestDotthzFile(unittest.TestCase):
         )
 
         measurements = {
-            "Measurement 1": DotthzMeasurement(datasets=datasets, meta_data=meta_data)
+            "Measurement 1": DotthzMeasurement()
         }
 
         with DotthzFile(path, "w") as file_to_write:
@@ -220,7 +296,7 @@ class TestDotthzFile(unittest.TestCase):
                 file_to_write.measurements[name] = measurement
 
         with DotthzFile(path, "r+") as file_to_extend:
-            file_to_extend.measurements["Measurement 1"].datasets["ds1"][0, 0] = 0.0
+            file_to_extend.measurements["Measurement 1"] = DotthzMeasurement()
 
         # Load from the temporary file
         with DotthzFile(path) as loaded_file:

--- a/tests/test_dotthz.py
+++ b/tests/test_dotthz.py
@@ -153,7 +153,7 @@ class TestDotthzFile(unittest.TestCase):
 
         with DotthzFile(path, "w") as file_to_write:
             for name, measurement in measurements.items():
-                file_to_write.write_measurement(name, measurement)
+                file_to_write.measurements[name] = measurement
 
         # Load from the temporary file
         with DotthzFile(path) as loaded_file:
@@ -189,6 +189,73 @@ class TestDotthzFile(unittest.TestCase):
         # Clean up temporary file
         os.remove(path)
 
+    def test_dotthz_extend_existing_measurement(self):
+        with NamedTemporaryFile(delete=False) as temp_file:
+            path = temp_file.name
+
+        # Initialize test data for Dotthz
+        datasets = {
+            "ds1": np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
+        }
+        meta_data = DotthzMetaData(
+            user="Test User",
+            email="test@example.com",
+            orcid="0000-0001-2345-6789",
+            institution="Test Institute",
+            description="Test description",
+            md={"md1": "Thickness (mm)"},
+            version="1.00",
+            mode="Test mode",
+            instrument="Test instrument",
+            time="12:34:56",
+            date="2024-11-08"
+        )
+
+        measurements = {
+            "Measurement 1": DotthzMeasurement(datasets=datasets, meta_data=meta_data)
+        }
+
+        with DotthzFile(path, "w") as file_to_write:
+            for name, measurement in measurements.items():
+                file_to_write.measurements[name] = measurement
+
+        with DotthzFile(path, "r+") as file_to_extend:
+            file_to_extend.measurements["Measurement 1"].datasets["ds1"][0, 0] = 0.0
+
+        # Load from the temporary file
+        with DotthzFile(path) as loaded_file:
+            # Compare original and loaded data
+            self.assertEqual(len(measurements), len(loaded_file.measurements))
+
+            for group_name, measurement in file_to_write.measurements.items():
+                loaded_measurement = loaded_file[group_name]
+                self.assertIsNotNone(loaded_measurement)
+
+                # Compare metadata fields
+                self.assertEqual(measurement.meta_data.user, loaded_measurement.meta_data.user)
+                self.assertEqual(measurement.meta_data.email, loaded_measurement.meta_data.email)
+                self.assertEqual(measurement.meta_data.orcid, loaded_measurement.meta_data.orcid)
+                self.assertEqual(measurement.meta_data.institution, loaded_measurement.meta_data.institution)
+                self.assertEqual(measurement.meta_data.description, loaded_measurement.meta_data.description)
+                self.assertEqual(measurement.meta_data.version, loaded_measurement.meta_data.version)
+                self.assertEqual(measurement.meta_data.mode, loaded_measurement.meta_data.mode)
+                self.assertEqual(measurement.meta_data.instrument, loaded_measurement.meta_data.instrument)
+                self.assertEqual(measurement.meta_data.time, loaded_measurement.meta_data.time)
+                self.assertEqual(measurement.meta_data.date, loaded_measurement.meta_data.date)
+
+                # Compare metadata's key-value pairs
+                self.assertEqual(measurement.meta_data.md, loaded_measurement.meta_data.md)
+
+                # Compare datasets
+                self.assertEqual(len(measurement.datasets), len(loaded_measurement.datasets))
+
+                for dataset_name, dataset in measurement.datasets.items():
+                    loaded_dataset = loaded_measurement.datasets[dataset_name]
+                    self.assertIsNotNone(loaded_dataset)
+                    np.testing.assert_array_equal(np.array([[0.0, 2.0], [3.0, 4.0]], dtype=np.float32), loaded_dataset)
+
+        # Clean up temporary file
+        os.remove(path)
 
 
 if __name__ == "__main__":

--- a/tests/test_dotthz.py
+++ b/tests/test_dotthz.py
@@ -86,19 +86,16 @@ class TestDotthzFile(unittest.TestCase):
             date="2024-11-08"
         )
 
-        measurements = {
-            "Measurement 1": DotthzMeasurement(datasets=datasets, meta_data=meta_data)
-        }
-
         with DotthzFile(path, "w") as file_to_write:
             # test writing measurement by measurement
-            for name, measurement in measurements.items():
-                file_to_write.measurements[name] = measurement
+            file_to_write.measurements["Measurement 1"] = DotthzMeasurement()
+            file_to_write.measurements["Measurement 1"].meta_data = meta_data
+            file_to_write.measurements["Measurement 1"].datasets = datasets
 
         # Load from the temporary file
         with DotthzFile(path) as loaded_file:
             # Compare original and loaded data
-            self.assertEqual(len(measurements), len(loaded_file.measurements))
+            self.assertEqual(1, len(loaded_file.measurements))
 
             loaded_measurement = loaded_file.measurements["Measurement 1"]
             self.assertIsNotNone(loaded_measurement)
@@ -154,18 +151,15 @@ class TestDotthzFile(unittest.TestCase):
             date="2024-11-08"
         )
 
-        measurements = {
-            "Measurement 1": DotthzMeasurement(datasets=datasets, meta_data=meta_data)
-        }
-
         with DotthzFile(path, "w") as file_to_write:
-            for name, measurement in measurements.items():
-                file_to_write.measurements[name] = measurement
+            file_to_write.measurements["Measurement 1"] = DotthzMeasurement()
+            file_to_write.measurements["Measurement 1"].meta_data = meta_data
+            file_to_write.measurements["Measurement 1"].datasets = datasets
 
         # Load from the temporary file
         with DotthzFile(path) as loaded_file:
             # Compare original and loaded data
-            self.assertEqual(len(measurements), len(loaded_file.measurements))
+            self.assertEqual(1, len(loaded_file.measurements))
 
             loaded_measurement = loaded_file["Measurement 1"]
             self.assertIsNotNone(loaded_measurement)
@@ -217,27 +211,23 @@ class TestDotthzFile(unittest.TestCase):
             date="2024-11-08"
         )
 
-        measurements = {
-            "Measurement 1": DotthzMeasurement(datasets=datasets, meta_data=meta_data)
-        }
-
         with DotthzFile(path, "w") as file_to_write:
-
-            for name, measurement in measurements.items():
-                file_to_write.measurements[name] = measurement
+            file_to_write.measurements["Measurement 1"] = DotthzMeasurement()
+            file_to_write.measurements["Measurement 1"].meta_data = meta_data
+            file_to_write.measurements["Measurement 1"].datasets = datasets
             file_to_write.measurements["Measurement 1"].datasets["ds1"][0, 0] = 0.0
-
-        # with DotthzFile(path, "r+") as file_to_extend:
-        #     file_to_extend.measurements["Measurement 1"].datasets["ds1"][0, 0] = 0.0
 
         # Load from the temporary file
         with DotthzFile(path) as loaded_file:
             # Compare original and loaded data
-            self.assertEqual(len(measurements), len(loaded_file.measurements))
+            self.assertEqual(1, len(loaded_file.measurements))
 
             for group_name, measurement in file_to_write.measurements.items():
                 loaded_measurement = loaded_file[group_name]
+                print(loaded_measurement.datasets)
+
                 self.assertIsNotNone(loaded_measurement)
+                self.assertIsNotNone(measurement)
 
                 # Compare metadata fields
                 self.assertEqual(measurement.meta_data.user, loaded_measurement.meta_data.user)

--- a/tests/test_dotthz.py
+++ b/tests/test_dotthz.py
@@ -19,19 +19,18 @@ class TestDotthzFile(unittest.TestCase):
 
             # Load data from the original file
             with DotthzFile(path) as original_dotthz_file, DotthzFile(copy_file_path, "w") as copied_dotthz_file:
-                original_measurements = original_dotthz_file.get_measurements()
-                for name, measurement in original_measurements.items():
-                    # Save the data to the new temporary file
-                    copied_dotthz_file.write_measurement(name, measurement)
+                # test writing all measurements at once
+                original_measurements = original_dotthz_file.measurements
+                copied_dotthz_file.measurements = original_measurements
 
             # Load data from the new copy file
             with DotthzFile(path) as copied_dotthz_file:
 
                 # Compare the original and copied Dotthz structures
-                self.assertEqual(len(original_measurements), len(copied_dotthz_file.get_measurements()))
+                self.assertEqual(len(original_measurements), len(copied_dotthz_file.measurements))
 
                 for group_name, original_measurement in original_measurements.items():
-                    copied_measurement = copied_dotthz_file.get_measurement(group_name)
+                    copied_measurement = copied_dotthz_file.measurements[group_name]
                     self.assertIsNotNone(copied_measurement)
 
                     # Compare metadata fields
@@ -88,16 +87,17 @@ class TestDotthzFile(unittest.TestCase):
         }
 
         with DotthzFile(path, "w") as file_to_write:
+            # test writing measurement by measurement
             for name, measurement in measurements.items():
-                file_to_write.write_measurement(name, measurement)
+                file_to_write.measurements[name] = measurement
 
         # Load from the temporary file
         with DotthzFile(path) as loaded_file:
             # Compare original and loaded data
-            self.assertEqual(len(measurements), len(loaded_file.get_measurements()))
+            self.assertEqual(len(measurements), len(loaded_file.measurements))
 
-            for group_name, measurement in file_to_write.get_measurements().items():
-                loaded_measurement = loaded_file.get_measurement(group_name)
+            for group_name, measurement in file_to_write.measurements.items():
+                loaded_measurement = loaded_file.measurements[group_name]
                 self.assertIsNotNone(loaded_measurement)
 
                 # Compare metadata fields
@@ -124,6 +124,71 @@ class TestDotthzFile(unittest.TestCase):
 
         # Clean up temporary file
         os.remove(path)
+
+    def test_dotthz_key(self):
+        with NamedTemporaryFile(delete=False) as temp_file:
+            path = temp_file.name
+
+        # Initialize test data for Dotthz
+        datasets = {
+            "ds1": np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
+        }
+        meta_data = DotthzMetaData(
+            user="Test User",
+            email="test@example.com",
+            orcid="0000-0001-2345-6789",
+            institution="Test Institute",
+            description="Test description",
+            md={"md1": "Thickness (mm)"},
+            version="1.00",
+            mode="Test mode",
+            instrument="Test instrument",
+            time="12:34:56",
+            date="2024-11-08"
+        )
+
+        measurements = {
+            "Measurement 1": DotthzMeasurement(datasets=datasets, meta_data=meta_data)
+        }
+
+        with DotthzFile(path, "w") as file_to_write:
+            for name, measurement in measurements.items():
+                file_to_write.write_measurement(name, measurement)
+
+        # Load from the temporary file
+        with DotthzFile(path) as loaded_file:
+            # Compare original and loaded data
+            self.assertEqual(len(measurements), len(loaded_file.measurements))
+
+            for group_name, measurement in file_to_write.measurements.items():
+                loaded_measurement = loaded_file[group_name]
+                self.assertIsNotNone(loaded_measurement)
+
+                # Compare metadata fields
+                self.assertEqual(measurement.meta_data.user, loaded_measurement.meta_data.user)
+                self.assertEqual(measurement.meta_data.email, loaded_measurement.meta_data.email)
+                self.assertEqual(measurement.meta_data.orcid, loaded_measurement.meta_data.orcid)
+                self.assertEqual(measurement.meta_data.institution, loaded_measurement.meta_data.institution)
+                self.assertEqual(measurement.meta_data.description, loaded_measurement.meta_data.description)
+                self.assertEqual(measurement.meta_data.version, loaded_measurement.meta_data.version)
+                self.assertEqual(measurement.meta_data.mode, loaded_measurement.meta_data.mode)
+                self.assertEqual(measurement.meta_data.instrument, loaded_measurement.meta_data.instrument)
+                self.assertEqual(measurement.meta_data.time, loaded_measurement.meta_data.time)
+                self.assertEqual(measurement.meta_data.date, loaded_measurement.meta_data.date)
+
+                # Compare metadata's key-value pairs
+                self.assertEqual(measurement.meta_data.md, loaded_measurement.meta_data.md)
+
+                # Compare datasets
+                self.assertEqual(len(measurement.datasets), len(loaded_measurement.datasets))
+                for dataset_name, dataset in measurement.datasets.items():
+                    loaded_dataset = loaded_measurement.datasets[dataset_name]
+                    self.assertIsNotNone(loaded_dataset)
+                    np.testing.assert_array_equal(dataset, loaded_dataset)
+
+        # Clean up temporary file
+        os.remove(path)
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This will bump to version 1.0.0.

### Added:

* `DotTHzFile` now allows accessing measurements like a dictionary: `file[name]`
* When setting a measurement value either in `file[name]` or `file.measurements[name]` it is automatically written to
  the file on the disk.

### Deprecated:

* Usage of `file.get_measurements()` is replaced by `file.measurements`
* Usage of `file.get_measurement(name)` is replaced by `file[name]` or `file.measurements[name]`
