### PR TITLE
Update set_metadata in pydotthz.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the `pydotthz` package will be documented in this file.
 
 # Unreleased
 
+* Update md and mdDescription assignment.
+* Updated user_info such that the parameter can still be formed even if any items of orcid, user, email or institution is missing.
 * ...
 
 ## 1.0.0 - 14.5.2025

--- a/pydotthz/pydotthz.py
+++ b/pydotthz/pydotthz.py
@@ -285,7 +285,7 @@ class DotthzMeasurementWrapper:
         self.group.attrs["user"] = user_info
 
         # Set additional metadata fields (md1, md2, etc.)
-        for i, (key, value) in enumerate(metadata.md.items(), start=1):
+        for i, value in enumerate(metadata.md.values(), start=1):
             self.group.attrs[f"md{i}"] = value
 
         # Optionally, add "mdDescription" to describe which fields are included

--- a/pydotthz/pydotthz.py
+++ b/pydotthz/pydotthz.py
@@ -276,16 +276,17 @@ class DotthzMeasurementWrapper:
         self.group.attrs["version"] = metadata.version
 
         # Handle user metadata
-        user_info = "/".join((metadata.orcid,
-                              metadata.user,
-                              metadata.email,
-                              metadata.institution))
+        user_info = "/".join(x or "" for x in (
+            metadata.orcid,
+            metadata.user,
+            metadata.email,
+            metadata.institution))
 
         self.group.attrs["user"] = user_info
 
         # Set additional metadata fields (md1, md2, etc.)
-        for key, value in metadata.md.items():
-            self.group.attrs[key] = value
+        for i, (key, value) in enumerate(metadata.md.items(), start=1):
+            self.group.attrs[f"md{i}"] = value
 
         # Optionally, add "mdDescription" to describe which fields are included
         md_description = ",".join(metadata.md.keys())


### PR DESCRIPTION
1. Update md and mdDescription assignment. User specifies the descriptions of the md (e.g. thickness, temperature) and these are assigned to mdDescription accordingly. The set_metadata code automatically assigns data to md1, md2, etc. attributes.
Resolves #12 

2. updated user_info such that the parameter can still be formed even if any items of orcid, user, email or institution is missing.